### PR TITLE
Users/stfrance/downgrade node version

### DIFF
--- a/make.js
+++ b/make.js
@@ -124,8 +124,6 @@ target.loc = function () {
 }
 
 target.test = function () {
-    target.build();
-
     run('tsc -p ./test --outDir ' + testPath, true);
     cp('-R', path.join(__dirname, 'test', 'data'), testPath);
     //cp('-Rf', rp('test/scripts'), testPath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "VSTS Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "devDependencies": {
     "typescript": "^2.2.1",
-    "node": "^8.0.19",
-    "@types/node": "^8.0.19",
+    "node": "^6.12.0",
+    "@types/node": "^6.12.0",
     "mocha": "^3.2.0",
     "@types/mocha": "^2.2.41",
     "shelljs": "^0.7.6",

--- a/test/toolTests.ts
+++ b/test/toolTests.ts
@@ -159,7 +159,7 @@ describe('Tool Tests', function () {
     }
 
     it('installs a zip and finds it', function () {
-        this.timeout(2000);
+        this.timeout(3000);
 
         return new Promise<void>(async (resolve, reject) => {
             try {


### PR DESCRIPTION
1. Remove build from test make command. We want to build targeting a certain node version then run tests using other versions. We don't want to build every time we test. (I will update build definitions)
2. Downgrade node dev dependency version
3. Increase timeout for a test that fails intermittently