### PR TITLE
Add more details to debug logs for downloadTool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.5.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -438,9 +438,9 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vsts-task-lib": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.6.tgz",
-      "integrity": "sha1-9sqGS3sDsS23N8nV/2kThGNpEFY=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz",
+      "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typed-rest-client": "1.0.7",
     "uuid": "^3.0.1",
     "@types/uuid": "^3.0.1",
-    "vsts-task-lib": "2.0.6"
+    "vsts-task-lib": "2.4.0"
   },
   "devDependencies": {
     "typescript": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-tool-lib",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "VSTS Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/tool.ts
+++ b/tool.ts
@@ -246,7 +246,7 @@ export async function downloadTool(url: string, fileName?: string): Promise<stri
                             fileSize = fs.statSync(destPath).size;
                             tl.debug(`file size: ${fileSize} bytes`);
                         } catch (err) {
-                            reject(new Error(`Unable to find file size for ${destPath}`));
+                            tl.debug(`Unable to find file size for ${destPath}`);
                         }
 
                         if (contentLength 

--- a/tool.ts
+++ b/tool.ts
@@ -228,7 +228,7 @@ export async function downloadTool(url: string, fileName?: string): Promise<stri
                 throw err;
             }
 
-            const contentLength = Number(response.message.headers['content-length']);
+            const contentLength: number = Number(response.message.headers['content-length']);
             if(contentLength) {
                 tl.debug(`content-length: ${contentLength} bytes`);
             } else {


### PR DESCRIPTION
This change adds more logging when we do downloadTool.

1. If it exists, log content-length header
2. Log size of file on disk
3. Ensure content-length header and size on disk match
4. Bump version of vsts-task-lib to latest

Need to test if this is OK for large file sizes.

Based on request from #27. Should also resolve #29 and #16.