### PR TITLE
Add handlers option to downloadTool

### DIFF
--- a/test/tests/toolTests.ts
+++ b/test/tests/toolTests.ts
@@ -178,13 +178,13 @@ describe('Tool Tests', function () {
 
         return new Promise<void>(async (resolve, reject) => {
             // General parameters:
-            let username = "usr";
-            let correctPassword = "pass";
-            let url = "http://httpbin.org/basic-auth/" + username + "/" + correctPassword;
+            let username: string = "usr";
+            let correctPassword: string = "pass";
+            let url: string = "http://httpbin.org/basic-auth/" + username + "/" + correctPassword;
 
             // First try downloading with WRONG credentials and verify receiving status code 401:
             try {
-                let basicAuthHandler = [new hm.BasicCredentialHandler(username, "WrongPassword")];
+                let basicAuthHandler: hm.BasicCredentialHandler[] = [new hm.BasicCredentialHandler(username, "WrongPassword")];
                 let downPath: string = await toolLib.downloadTool(url, null, basicAuthHandler);
 
                 reject(new Error('Should have received status code 401 when downloading with bad credentials'));
@@ -194,7 +194,7 @@ describe('Tool Tests', function () {
                     assert.equal(err['httpStatusCode'], 401, 'Should have received status code 401 when downloading with bad credentials');
 
                     // Then try downloading with the CORRECT credentials and verify file downloaded:
-                    let basicAuthHandler = [new hm.BasicCredentialHandler(username, correctPassword)];
+                    let basicAuthHandler: hm.BasicCredentialHandler[] = [new hm.BasicCredentialHandler(username, correctPassword)];
                     let downPath: string = await toolLib.downloadTool(url, null, basicAuthHandler);
 
                     assert(tl.exist(downPath), 'File should have been downloaded');

--- a/tool.ts
+++ b/tool.ts
@@ -19,7 +19,6 @@ let requestOptions = {
     proxy: tl.getHttpProxyConfiguration(),
     cert: tl.getHttpCertConfiguration()
 } as ifm.IRequestOptions;
-let http: httpm.HttpClient = new httpm.HttpClient(userAgent, null, requestOptions);
 tl.setResourcePath(path.join(__dirname, 'lib.json'));
 
 export function debug(message: string): void {
@@ -194,10 +193,13 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
  *
  * @param url       url of tool to download
  * @param fileName  optional fileName.  Should typically not use (will be a guid for reliability). Can pass fileName with an absolute path.
+ * @param handlers  optional handlers array.  Handlers to pass to the HttpClient for the tool download.
  */
-export async function downloadTool(url: string, fileName?: string): Promise<string> {
+export async function downloadTool(url: string, fileName?: string, handlers?: ifm.IRequestHandler[]): Promise<string> {
     return new Promise<string>(async (resolve, reject) => {
         try {
+            handlers = handlers || null;
+            let http: httpm.HttpClient = new httpm.HttpClient(userAgent, handlers, requestOptions);
             tl.debug(fileName);
             fileName = fileName || uuidV4();
 
@@ -521,6 +523,7 @@ function _createExtractFolder(dest?: string): string {
  * @param regex     regex to use for version matches
  */
 export async function scrape(url: string, regex: RegExp): Promise<string[]> {
+    let http: httpm.HttpClient = new httpm.HttpClient(userAgent, null, requestOptions);
     let output: string = await (await http.get(url)).readBody();
 
     let matches = output.match(regex);

--- a/tool.ts
+++ b/tool.ts
@@ -193,7 +193,7 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
  *
  * @param url       url of tool to download
  * @param fileName  optional fileName.  Should typically not use (will be a guid for reliability). Can pass fileName with an absolute path.
- * @param handlers  optional handlers array.  Handlers to pass to the HttpClient for the tool download.
+ * @param handlers  optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
  */
 export async function downloadTool(url: string, fileName?: string, handlers?: ifm.IRequestHandler[]): Promise<string> {
     return new Promise<string>(async (resolve, reject) => {
@@ -521,9 +521,11 @@ function _createExtractFolder(dest?: string): string {
  *
  * @param url       url to scrape
  * @param regex     regex to use for version matches
+ * @param handlers  optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
  */
-export async function scrape(url: string, regex: RegExp): Promise<string[]> {
-    let http: httpm.HttpClient = new httpm.HttpClient(userAgent, null, requestOptions);
+export async function scrape(url: string, regex: RegExp, handlers?: ifm.IRequestHandler[]): Promise<string[]> {
+    handlers = handlers || null;
+    let http: httpm.HttpClient = new httpm.HttpClient(userAgent, handlers, requestOptions);
     let output: string = await (await http.get(url)).readBody();
 
     let matches = output.match(regex);


### PR DESCRIPTION
Adding an optional input of http client handlers to the downloadTool to allow an authenticated download.