### PR TITLE
Fix broken build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - task: CopyFiles@2
     inputs:
       sourceFolder: '$(Build.SourcesDirectory)'
-      contents: 
+      contents: |
         '*.tgz'
         'package.json'
       targetFolder: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
The last commit on https://github.com/microsoft/azure-pipelines-tool-lib/pull/60 broke it so that it gives a parse error - https://dev.azure.com/ms/azure-pipelines-tool-lib/_build/results?buildId=59519&view=results