### PR TITLE
removing 'z' flag for tar invocation 

### DIFF
--- a/tool.ts
+++ b/tool.ts
@@ -449,7 +449,7 @@ export async function extractTar(file: string, destination?: string): Promise<st
     let dest = _createExtractFolder(destination);
 
     let tr: trm.ToolRunner = tl.tool('tar');
-    tr.arg(['xzC', dest, '-f', file]);
+    tr.arg(['xC', dest, '-f', file]);
 
     await tr.exec();
     return dest;


### PR DESCRIPTION
z flag forces gz and overrides file type detection.  fixes https://github.com/microsoft/azure-pipelines-tool-lib/issues/69