### PR TITLE
bump shelljs and fix httpbin errors in toolTest.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -192,6 +192,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -224,6 +230,15 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -253,10 +268,19 @@
       "dev": true
     },
     "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+      "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -442,9 +466,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "pathval": {
@@ -480,12 +504,13 @@
       }
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
       }
     },
     "sax": {
@@ -505,9 +530,9 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/xml2js": "^0.4.4",
     "mocha": "^3.2.0",
     "nock": "9.6.1",
-    "shelljs": "^0.7.6",
+    "shelljs": "^0.8.4",
     "typescript": "3.1.5",
     "xml2js": "^0.4.17"
   }

--- a/test/tests/toolTests.ts
+++ b/test/tests/toolTests.ts
@@ -35,7 +35,7 @@ describe('Tool Tests', function () {
 
         return new Promise<void>(async (resolve, reject) => {
             try {
-                let downPath: string = await toolLib.downloadTool("https://httpbin.org/bytes/100");
+                let downPath: string = await toolLib.downloadTool("https://httpbingo.org/bytes/100");
                 toolLib.debug('downloaded path: ' + downPath);
 
                 assert(tl.exist(downPath), 'downloaded file exists');
@@ -55,7 +55,7 @@ describe('Tool Tests', function () {
         return new Promise<void>(async (resolve, reject) => {
             try {
                 
-                let downPath: string = await toolLib.downloadTool("https://httpbin.org/redirect-to?url=" + encodeURI('https://httpbin.org/bytes/100') + "&status_code=302");
+                let downPath: string = await toolLib.downloadTool("https://httpbingo.org/redirect-to?url=" + encodeURI('https://httpbin.org/bytes/100') + "&status_code=302");
                 toolLib.debug('downloaded path: ' + downPath);
 
                 assert(tl.exist(downPath), 'downloaded file exists');
@@ -76,7 +76,7 @@ describe('Tool Tests', function () {
             try {
                 let tempDownloadFolder: string = 'temp_' + Math.floor(Math.random() * 2000000000);
                 let absolutePath: string = path.join(tempPath, tempDownloadFolder);
-                let downPath: string = await toolLib.downloadTool("https://httpbin.org/bytes/100", absolutePath);
+                let downPath: string = await toolLib.downloadTool("https://httpbingo.org/bytes/100", absolutePath);
                 toolLib.debug('downloaded path: ' + downPath);
                 
                 assert(tl.exist(downPath), 'downloaded file exists');
@@ -93,7 +93,7 @@ describe('Tool Tests', function () {
     it('has status code in exception dictionary for HTTP error code responses', async function() {
         return new Promise<void>(async(resolve, reject)=> {
             try {
-                let errorCodeUrl: string = "https://httpbin.org/status/400";
+                let errorCodeUrl: string = "https://httpbingo.org/status/400";
                 let downPath: string = await toolLib.downloadTool(errorCodeUrl);
 
                 reject('a file was downloaded but it shouldnt have been');
@@ -109,7 +109,7 @@ describe('Tool Tests', function () {
     it('works with redirect code 302', async function () {
         return new Promise<void>(async(resolve, reject)=> {
             try {
-                let statusCodeUrl: string = "https://httpbin.org/redirect-to?url=https%3A%2F%2Fexample.com%2F&status_code=302";
+                let statusCodeUrl: string = "https://httpbingo.org/redirect-to?url=https%3A%2F%2Fexample.com%2F&status_code=302";
                 let downPath: string = await toolLib.downloadTool(statusCodeUrl);
 
                 resolve();
@@ -125,7 +125,7 @@ describe('Tool Tests', function () {
 
         return new Promise<void>(async (resolve, reject) => {
             try {
-                let downPath: string = await toolLib.downloadTool("https://httpbin.org/bytes/100");
+                let downPath: string = await toolLib.downloadTool("https://httpbingo.org/bytes/100");
                 toolLib.debug('downloaded path: ' + downPath);
 
                 assert(tl.exist(downPath), 'downloaded file exists');
@@ -151,8 +151,8 @@ describe('Tool Tests', function () {
 
         return new Promise<void>(async (resolve, reject) => {
             try {
-                let downPath1_1: string = await toolLib.downloadTool("https://httpbin.org/bytes/100");
-                let downPath1_2: string = await toolLib.downloadTool("https://httpbin.org/bytes/100");
+                let downPath1_1: string = await toolLib.downloadTool("https://httpbingo.org/bytes/100");
+                let downPath1_2: string = await toolLib.downloadTool("https://httpbingo.org/bytes/100");
 
                 toolLib.cacheFile(downPath1_1, 'foo', 'foo', '1.1.0');
                 toolLib.cacheFile(downPath1_2, 'foo', 'foo', '1.2.0');


### PR DESCRIPTION
bump shelljs to 0.8.4 to fix an arbitrary command injection vulnerability that was fixed in 0.8.3. Also, http://httpbin.org/redirect-to? is broken, so tests were failing. I replaced with httpbingo.org for the same tests.