### PR TITLE
Set up schedule and notifications for the localization pipeline

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -39,14 +39,14 @@ stages:
     - powershell: |
         $body = '{"text": "Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification'
+      displayName: 'Send Slack notification about PR opened'
       condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
         $body = '{"text": "Something went wrong while creating tool-lib localization update PR. Build: ' + $buildUrl + '"}'
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification'
+      displayName: 'Send Slack notification about error'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - task: PublishBuildArtifacts@1

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -13,16 +13,27 @@ schedules:
 stages:
 - stage: __default
   jobs:
-  - job: Job1
+  - job: LocalizationUpdate
     pool:
       vmImage: windows-latest
     steps:
     - powershell: |
-        $week = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).week
-        Write-Host "##vso[task.setvariable variable=week]$week"
-      displayName: "Determine the number of the week in the sprint"
+        $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
+        Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"
+        Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
+      displayName: "Determine the number of the week in the sprint and sprint number"
+
+    - powershell: |
+        git config --global user.email "$(github_email)"
+        git config --global user.name "$(username)"
+        git checkout -b Localization origin/Localization
+        git merge origin/master
+        git push origin Localization
+      displayName: "Sync with master branch"
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - task: OneLocBuild@2
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -32,22 +43,52 @@ stages:
         repoType: 'gitHub'
         prSourceBranchPrefix: 'Localize'
         gitHubPatVariable: '$(GitHubPAT)'
-        isAutoCompletePrSelected: false
+        isAutoCompletePrSelected: true
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - powershell: |
-        $body = '{"text": "Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
+        $date= Get-Date -Format "MMddyyyy"
+        $updateBranch="Localization-update_$date"
+        echo "##vso[task.setvariable variable=updateBranch]$updateBranch"
+
+        git checkout -b $updateBranch
+
+        Remove-Item -Recurse -Force Localize
+
+        git add -A
+        git commit -m "Removing Localize folder"
+        git push origin $updateBranch
+      displayName: Create and push localization update branch
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+    
+    - task: PowerShell@2
+      inputs:
+        filePath: 'open-pullrequest.ps1'
+        arguments: "-SourceBranch $(updateBranch)"
+        failOnStderr: true
+      env:
+        GH_TOKEN: '$(GitHubPAT)'
+      displayName: Open a PR
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+    
+    - powershell: |
+        $message="Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
+
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about PR opened'
-      condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $body = '{"text": "Something went wrong while creating tool-lib localization update PR. Build: ' + $buildUrl + '"}'
+        $message="Something went wrong while creating tool-lib localization update PR. Build: $buildUrl"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
+
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about error'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: drop'

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -17,6 +17,10 @@ stages:
     pool:
       vmImage: windows-latest
     steps:
+
+    - checkout: self
+      persistCredentials: true
+
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
         Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -2,6 +2,14 @@ name: $(Date:MMddyy)$(Rev:.rrrr)
 
 trigger: none
 
+schedules:
+- cron: 0 8 * * Mon # mm HH DD MM DW
+  displayName: Localization update
+  branches:
+    include: 
+    - Localization
+  always: true
+
 stages:
 - stage: __default
   jobs:
@@ -9,6 +17,11 @@ stages:
     pool:
       vmImage: windows-latest
     steps:
+    - powershell: |
+        $week = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).week
+        Write-Host "##vso[task.setvariable variable=week]$week"
+      displayName: "Determine the number of the week in the sprint"
+
     - task: OneLocBuild@2
       inputs:
         locProj: 'Localize/LocProject.json'
@@ -22,5 +35,19 @@ stages:
         isAutoCompletePrSelected: false
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+    - powershell: |
+        $body = '{"text": "Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification'
+      condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+
+    - powershell: |
+        $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
+        $body = '{"text": "Something went wrong while creating tool-lib localization update PR. Build: ' + $buildUrl + '"}'
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification'
+      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: drop'

--- a/open-pullrequest.ps1
+++ b/open-pullrequest.ps1
@@ -21,4 +21,5 @@ $body = "This PR was auto-generated with [the localization pipeline build]($buil
 gh pr create --head $SourceBranch --title 'Localization update' --body $body
 
 # Getting a link to the opened PR
-$env:PR_LINK = Get-PullRequest
+$PR_LINK = Get-PullRequest
+Write-Host "##vso[task.setvariable variable=PR_LINK]$PR_LINK"

--- a/open-pullrequest.ps1
+++ b/open-pullrequest.ps1
@@ -1,0 +1,24 @@
+param(
+    [Parameter(Mandatory)]
+    [string]
+    $SourceBranch
+) 
+
+function Get-PullRequest() {
+    $prInfo = (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
+    return $prInfo.html_url
+}
+
+$openedPR=Get-PullRequest
+
+if ($openedPR.length -ne 0) {
+    throw "A PR from $SourceBranch to master already exists."
+}
+
+$buildUrl = "$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$env:SYSTEM_TEAMPROJECT/_build/results?buildId=$env:BUILD_BUILDID&_a=summary"
+$body = "This PR was auto-generated with [the localization pipeline build]($buildUrl)."
+
+gh pr create --head $SourceBranch --title 'Localization update' --body $body
+
+# Getting a link to the opened PR
+$env:PR_LINK = Get-PullRequest


### PR DESCRIPTION
**Task name**: Localization pipeline definition

**Description**: 
Added schedule trigger to run the localization pipeline on the third week of a sprint on Mondays at 8 a.m. UTC,
Added Slack notifications about successful and failed builds.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#877](https://github.com/microsoft/build-task-team/issues/877)