### PR TITLE
Create PR in OneLocBuild task only on third week of sprint

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -53,11 +53,11 @@ stages:
         outDir: '$(Build.ArtifactStagingDirectory)'
         packageSourceAuth: 'patAuth'
         patVariable: '$(OneLocBuildPAT)'
-        # isCreatePrSelected: true
-        # repoType: 'gitHub'
-        # prSourceBranchPrefix: 'Localize'
-        # gitHubPatVariable: '$(GitHubPAT)'
-        # isAutoCompletePrSelected: true
+        isCreatePrSelected: $(shouldCreatePR)
+        repoType: 'gitHub'
+        prSourceBranchPrefix: 'Localize'
+        gitHubPatVariable: '$(GitHubPAT)'
+        isAutoCompletePrSelected: false
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -23,7 +23,7 @@ stages:
 
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        if (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual'))
+        if (($env:PR_CREATION_ENABLED -eq 'True') -and (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual')))
         {
           Write-Host "shouldCreatePR was set to true"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -23,6 +23,16 @@ stages:
 
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
+        if ($sprintInfo.week -eq 3)
+        {
+          Write-Host "shouldCreatePR was set to true"
+          Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  
+        }
+        else
+        {
+          Write-Host "shouldCreatePR was set to false"
+          Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($false)"
+        }
         Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"
         Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
       displayName: "Determine the number of the week in the sprint and sprint number"
@@ -34,69 +44,74 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - task: OneLocBuild@2
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
         packageSourceAuth: 'patAuth'
         patVariable: '$(OneLocBuildPAT)'
-        isCreatePrSelected: true
-        repoType: 'gitHub'
-        prSourceBranchPrefix: 'Localize'
-        gitHubPatVariable: '$(GitHubPAT)'
-        isAutoCompletePrSelected: true
+        # isCreatePrSelected: true
+        # repoType: 'gitHub'
+        # prSourceBranchPrefix: 'Localize'
+        # gitHubPatVariable: '$(GitHubPAT)'
+        # isAutoCompletePrSelected: true
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - task: PublishBuildArtifacts@1
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       displayName: 'Publish an artifact'
 
-    - powershell: |
-        $date= Get-Date -Format "MMddyyyy"
-        $updateBranch="Localization-update_$date"
-        echo "##vso[task.setvariable variable=updateBranch]$updateBranch"
+    # - powershell: |
+    #     $date= Get-Date -Format "MMddyyyy"
+    #     $updateBranch="Localization-update_$date"
+    #     echo "##vso[task.setvariable variable=updateBranch]$updateBranch"
 
-        git checkout -b $updateBranch
+    #     git checkout -b $updateBranch
 
-        Remove-Item -Recurse -Force Localize
+    #     Remove-Item -Recurse -Force Localize
 
-        git add -A
-        git commit -m "Removing Localize folder"
-        git push origin $updateBranch
-      displayName: Create and push localization update branch
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+    #     git add -A
+    #     git commit -m "Removing Localize folder"
+    #     git push origin $updateBranch
+    #   displayName: Create and push localization update branch
+    #   condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      #  condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
-    - task: PowerShell@2
-      inputs:
-        filePath: 'open-pullrequest.ps1'
-        arguments: "-SourceBranch $(updateBranch)"
-        failOnStderr: true
-      env:
-        GH_TOKEN: '$(GitHubPAT)'
-      displayName: Open a PR
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+    # - task: PowerShell@2
+    #   inputs:
+    #     filePath: 'open-pullrequest.ps1'
+    #     arguments: "-SourceBranch $(updateBranch)"
+    #     failOnStderr: true
+    #   env:
+    #     GH_TOKEN: '$(GitHubPAT)'
+    #   displayName: Open a PR
+    #   condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
-    - powershell: |
-        $message="Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
-        $body = [PSCustomObject]@{
-          text = $message
-        } | ConvertTo-Json
+    # - powershell: |
+    #     $message="Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
+    #     $body = [PSCustomObject]@{
+    #       text = $message
+    #     } | ConvertTo-Json
 
-        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification about PR opened'
-      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+    #     Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+    #   displayName: 'Send Slack notification about PR opened'
+    #   condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
-    - powershell: |
-        $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $message="Something went wrong while creating tool-lib localization update PR. Build: $buildUrl"
-        $body = [PSCustomObject]@{
-          text = $message
-        } | ConvertTo-Json
+    # - powershell: |
+    #     $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
+    #     $message="Something went wrong while creating tool-lib localization update PR. Build: $buildUrl"
+    #     $body = [PSCustomObject]@{
+    #       text = $message
+    #     } | ConvertTo-Json
 
-        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification about error'
-      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+    #     Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+    #   displayName: 'Send Slack notification about error'
+    #   condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -23,7 +23,7 @@ stages:
 
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        if ($sprintInfo.week -eq 3)
+        if (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual'))
         {
           Write-Host "shouldCreatePR was set to true"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  
@@ -42,10 +42,10 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
 
     - task: OneLocBuild@2
-      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -60,7 +60,7 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - task: PublishBuildArtifacts@1
-      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
       displayName: 'Publish an artifact'
 
     - powershell: |

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -23,7 +23,7 @@ stages:
 
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        if ($sprintInfo.week -eq 2)
+        if ($sprintInfo.week -eq 3)
         {
           Write-Host "shouldCreatePR was set to true"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -42,10 +42,10 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual'))
+      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual')))
 
     - task: OneLocBuild@2
-      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual'))
+      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual')))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -60,7 +60,7 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - task: PublishBuildArtifacts@1
-      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual'))
+      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual')))
       displayName: 'Publish an artifact'
 
     - powershell: |
@@ -86,7 +86,7 @@ stages:
       env:
         GH_TOKEN: '$(GitHubPAT)'
       displayName: Open a PR
-      condition: and(succeeded(), or(and(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
     - powershell: |
         $message="Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -42,10 +42,10 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual'))
 
     - task: OneLocBuild@2
-      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual'))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -60,7 +60,7 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - task: PublishBuildArtifacts@1
-      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(eq(variables['build.reason'], 'Schedule'), eq(variables['build.reason'], 'Manual'))
       displayName: 'Publish an artifact'
 
     - powershell: |

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -44,12 +44,10 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
-      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      # condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - task: OneLocBuild@2
-      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
-      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      # condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -64,8 +62,7 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - task: PublishBuildArtifacts@1
-      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
-      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      # condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       displayName: 'Publish an artifact'
 
     # - powershell: |

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -23,7 +23,7 @@ stages:
 
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        if ($sprintInfo.week -eq 3)
+        if ($sprintInfo.week -eq 2)
         {
           Write-Host "shouldCreatePR was set to true"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  
@@ -33,8 +33,6 @@ stages:
           Write-Host "shouldCreatePR was set to false"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($false)"
         }
-        Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"
-        Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
       displayName: "Determine the number of the week in the sprint and sprint number"
 
     - powershell: |
@@ -44,10 +42,10 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      # condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - task: OneLocBuild@2
-      # condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -62,53 +60,51 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
     - task: PublishBuildArtifacts@1
-      # condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       displayName: 'Publish an artifact'
 
-    # - powershell: |
-    #     $date= Get-Date -Format "MMddyyyy"
-    #     $updateBranch="Localization-update_$date"
-    #     echo "##vso[task.setvariable variable=updateBranch]$updateBranch"
+    - powershell: |
+        $date= Get-Date -Format "MMddyyyy"
+        $updateBranch="Localization-update_$date"
+        echo "##vso[task.setvariable variable=updateBranch]$updateBranch"
 
-    #     git checkout -b $updateBranch
+        git checkout -b $updateBranch
 
-    #     Remove-Item -Recurse -Force Localize
+        Remove-Item -Recurse -Force Localize
 
-    #     git add -A
-    #     git commit -m "Removing Localize folder"
-    #     git push origin $updateBranch
-    #   displayName: Create and push localization update branch
-    #   condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
-      #  condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+        git add -A
+        git commit -m "Removing Localize folder"
+        git push origin $updateBranch
+      displayName: Create and push localization update branch
+      condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
-    # - task: PowerShell@2
-    #   inputs:
-    #     filePath: 'open-pullrequest.ps1'
-    #     arguments: "-SourceBranch $(updateBranch)"
-    #     failOnStderr: true
-    #   env:
-    #     GH_TOKEN: '$(GitHubPAT)'
-    #   displayName: Open a PR
-    #   condition: and(succeeded(), or(and(eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
-      # condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+    - task: PowerShell@2
+      inputs:
+        filePath: 'open-pullrequest.ps1'
+        arguments: "-SourceBranch $(updateBranch)"
+        failOnStderr: true
+      env:
+        GH_TOKEN: '$(GitHubPAT)'
+      displayName: Open a PR
+      condition: and(succeeded(), or(and(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
-    # - powershell: |
-    #     $message="Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
-    #     $body = [PSCustomObject]@{
-    #       text = $message
-    #     } | ConvertTo-Json
+    - powershell: |
+        $message="Created tool-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
 
-    #     Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-    #   displayName: 'Send Slack notification about PR opened'
-    #   condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification about PR opened'
+      condition: and(succeeded(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))
 
-    # - powershell: |
-    #     $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-    #     $message="Something went wrong while creating tool-lib localization update PR. Build: $buildUrl"
-    #     $body = [PSCustomObject]@{
-    #       text = $message
-    #     } | ConvertTo-Json
+    - powershell: |
+        $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
+        $message="Something went wrong while creating tool-lib localization update PR. Build: $buildUrl"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
 
-    #     Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-    #   displayName: 'Send Slack notification about error'
-    #   condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification about error'
+      condition: and(failed(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -55,7 +55,7 @@ stages:
         repoType: 'gitHub'
         prSourceBranchPrefix: 'Localize'
         gitHubPatVariable: '$(GitHubPAT)'
-        isAutoCompletePrSelected: false
+        isAutoCompletePrSelected: true
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 


### PR DESCRIPTION
This PR should resolve the issue with the incidents on the localization team side caused by missed artifacts in pipeline runs.
In previous behavior we have skipped all the tasks in case it is not the third week of the sprint and artifacts weren't published.

In new behavior, artifacts will be generated every week, but the update of the corresponding branches will only take place on the last week of the sprint. In case of manual run, PR will be created independent of the current week.
Also fixed condition for sending notification in case of successful PR creation.