### PR TITLE
Fix ci failures

### DIFF
--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -1,17 +1,15 @@
-
 steps:
+
+- task: NodeTool@0
+  displayName: Use Node 10.x
+  inputs:
+    versionSpec: "10.x"  
 
 - script: npm install
   displayName: 'npm install'
 
 - script: npm run build
   displayName: 'npm run build'
-
-# test with node 6
-- task: NodeTool@0
-  displayName: Use Node 6.10.3
-  inputs:
-    versionSpec: "6.10.3"  
 
 - script: npm test
   displayName: 'npm test'

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -3,7 +3,7 @@ steps:
 - task: NodeTool@0
   displayName: Use Node 10.x
   inputs:
-    versionSpec: "10.x"  
+    versionSpec: "10.24.1"
 
 - script: npm install
   displayName: 'npm install'

--- a/test/units/toolTests.ts
+++ b/test/units/toolTests.ts
@@ -43,7 +43,7 @@ describe('Tool Tests', function () {
             this.timeout(1000);
 
             console.log('node version: ' + process.version);
-            assert(process.version == 'v5.10.1' || process.version == 'v6.10.3' || process.version == 'v8.9.1', 'expected node v5.10.1, v6.10.3, or v8.9.1. actual: ' + process.version);
+            assert(process.version == 'v10.24.1', 'expected node v10.24.1. actual: ' + process.version);
 
             done();
         });

--- a/test/units/toolTests.ts
+++ b/test/units/toolTests.ts
@@ -249,7 +249,7 @@ describe('Tool Tests', function () {
     }
 
     it('installs a zip and finds it', function () {
-        this.timeout(2000);
+        this.timeout(10000);
 
         return new Promise<void>(async (resolve, reject) => {
             try {
@@ -299,7 +299,7 @@ describe('Tool Tests', function () {
     });
 
     it('installs a zip and extracts it to specified directory', function () {
-        this.timeout(2000);
+        this.timeout(10000);
 
         return new Promise<void>(async (resolve, reject) => {
             try {


### PR DESCRIPTION
Currently the CI is failing for two reasons:
1. We're testing with node 6, but typescript 4 does not support node 6; switching to node 10 because tool-lib 1.x is supposed to work on node 10
2. The zip installation tests exceed timeouts on windows