### PR TITLE
Fix ci failures on releases/0.x

### DIFF
--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -8,6 +8,8 @@ steps:
 - script: npm install
   displayName: 'npm install'
 
+- bash: cat ./package-lock.json
+
 - script: npm run build
   displayName: 'npm run build'
 

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -1,9 +1,9 @@
 steps:
 
 - task: NodeTool@0
-  displayName: Use Node 8.9.1
+  displayName: Use Node 6.10.3
   inputs:
-    versionSpec: "v8.9.1"
+    versionSpec: "6.10.3"
 
 - script: npm install
   displayName: 'npm install'

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -1,17 +1,15 @@
-
 steps:
+
+- task: NodeTool@0
+  displayName: Use Node 6.10.3
+  inputs:
+    versionSpec: "6.10.3"
 
 - script: npm install
   displayName: 'npm install'
 
 - script: npm run build
   displayName: 'npm run build'
-
-# test with node 6
-- task: NodeTool@0
-  displayName: Use Node 6.10.3
-  inputs:
-    versionSpec: "6.10.3"  
 
 - script: npm test
   displayName: 'npm test'

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -8,8 +8,6 @@ steps:
 - script: npm install
   displayName: 'npm install'
 
-- bash: cat ./package-lock.json
-
 - script: npm run build
   displayName: 'npm run build'
 

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -1,9 +1,9 @@
 steps:
 
 - task: NodeTool@0
-  displayName: Use Node 6.10.3
+  displayName: Use Node 8.9.1
   inputs:
-    versionSpec: "6.10.3"
+    versionSpec: "v8.9.1"
 
 - script: npm install
   displayName: 'npm install'

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/mocha": "^2.2.41",
     "@types/node": "^8.10.50",
     "@types/shelljs": "^0.7.9",
-    "@types/xml2js": "^0.4.4",
+    "@types/xml2js": "0.4.4",
     "mocha": "^3.2.0",
     "nock": "9.6.1",
     "shelljs": "^0.8.4",

--- a/test/units/toolTests.ts
+++ b/test/units/toolTests.ts
@@ -249,7 +249,7 @@ describe('Tool Tests', function () {
     }
 
     it('installs a zip and finds it', function () {
-        this.timeout(2000);
+        this.timeout(10000);
 
         return new Promise<void>(async (resolve, reject) => {
             try {
@@ -299,7 +299,7 @@ describe('Tool Tests', function () {
     });
 
     it('installs a zip and extracts it to specified directory', function () {
-        this.timeout(2000);
+        this.timeout(10000);
 
         return new Promise<void>(async (resolve, reject) => {
             try {


### PR DESCRIPTION
The CI for releases/0.x is failing for these reasons:
1. Node versions used for building and testing are inconsistent across systems; this is why we use node 6 everywhere now
2. Node 6 updates `@types/xml2js` to 0.4.8 from 0.4.4, which causes typescript build failures; this is why we locked it to 0.4.4
3. The zip installation tests exceed timeouts on windows