### PR TITLE
Update ubuntu image in the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 jobs:
-- job: 'Ubuntu_1604'
+- job: 'Ubuntu_1804'
   pool:
     vmImage: 'Ubuntu-18.04'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: 'Ubuntu_1604'
   pool:
-    vmImage: 'Ubuntu-16.04'
+    vmImage: 'Ubuntu-18.04'
 
   steps:
   - template: azure-pipelines-steps.yml


### PR DESCRIPTION
We need to update the image in the CI from `ubuntu-16.04` at least to `ubuntu-18.04` since
```
Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021.
```