### PR TITLE
Move notifications about Tool-lib Localization PR from Slack to MS Teams - Part 2

### DIFF
--- a/open-pullrequest.ps1
+++ b/open-pullrequest.ps1
@@ -4,6 +4,7 @@ param(
     $SourceBranch
 ) 
 
+# Getting a created PR. Result object has interface in accordance with article https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
 function Get-PullRequest() {
     return (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
 }

--- a/open-pullrequest.ps1
+++ b/open-pullrequest.ps1
@@ -5,13 +5,12 @@ param(
 ) 
 
 function Get-PullRequest() {
-    $prInfo = (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
-    return $prInfo.html_url
+    return (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
 }
 
 $openedPR = Get-PullRequest
 
-if ($openedPR.length -ne 0) {
+if ($openedPR.html_url.length -ne 0) {
     throw "A PR from $SourceBranch to master already exists."
 }
 
@@ -20,6 +19,10 @@ $body = "This PR was auto-generated with [the localization pipeline build]($buil
 
 gh pr create --head $SourceBranch --title 'Localization update' --body $body
 
+# Getting a number to the opened PR
+$PR_NUMBER = (Get-PullRequest).number
+Write-Host "##vso[task.setvariable variable=PR_NUMBER]$PR_NUMBER"
+
 # Getting a link to the opened PR
-$PR_LINK = Get-PullRequest
+$PR_LINK = (Get-PullRequest).html_url
 Write-Host "##vso[task.setvariable variable=PR_LINK]$PR_LINK"

--- a/send-notifications.ps1
+++ b/send-notifications.ps1
@@ -1,0 +1,45 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [bool]$IsPRCreated,
+    [Parameter(Mandatory = $true)]
+    [string]$RepoName
+)
+
+# Function sends Office 365 connector card to webhook.
+# It requires title and message text displyed in card and theme color used to hignlight card.
+function Send-Notification {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$titleText,
+        [Parameter(Mandatory = $true)]
+        [string]$messageText,
+        [Parameter(Mandatory = $true)]
+        [string]$themeColor
+    )
+
+    $body = [PSCustomObject]@{
+        title = $titleText
+        text = $messageText
+        themeColor = $themeColor
+    } | ConvertTo-Json
+
+    Invoke-RestMethod -Uri $($env:TEAMS_WEBHOOK) -Method Post -Body $body -ContentType 'application/json' 
+}
+
+$wikiLink = "[Wiki](https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/16150/Localization-update)"
+
+if ($IsPRCreated) {
+    $pullRequestLink = "[PR $($env:PR_NUMBER)]($($env:PR_LINK))"
+    $titleText = "Azure Pipelines $RepoName Localization update PR created - ID $($env:PR_NUMBER)"
+    $messageText = "Created $RepoName Localization update PR. Please review and approve/merge $pullRequestLink. Related article in $wikiLink."
+    $themeColor = "#FFFF00"
+}
+else {
+    $buildUrl = "$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$env:SYSTEM_TEAMPROJECT/_build/results?buildId=$($env:BUILD_BUILDID)&_a=summary"
+    $buildLink = "[ID $($env:BUILD_BUILDID)]($($buildUrl))"
+    $titleText = "Azure Pipelines $RepoName Localization build failed - ID $($env:BUILD_BUILDID)"
+    $messageText = "Failed to create $RepoName Localization update PR. Please review the results of failed build $buildLink. Related article in $wikiLink."
+    $themeColor = "#FF0000"
+}
+
+Send-Notification -titleText $titleText -messageText $messageText -themeColor $themeColor


### PR DESCRIPTION
**IMPORTANT - The PR must be completed with PR https://github.com/microsoft/azure-pipelines-tool-lib/pull/145 at the same time.**

---

Move notifications about Tool-lib Localization PR from Slack to MS Teams. Content of notifications was updated.