### PR TITLE
Add support for custom authorization header value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/tool.ts
+++ b/tool.ts
@@ -199,7 +199,12 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
  * @param handlers  optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
  * @param auth      optional custom auth header value.  This is passed as a HTTP header to the download client.
  */
-export async function downloadTool(url: string, fileName?: string, handlers?: ifm.IRequestHandler[], auth?: string): Promise<string> {
+export async function downloadTool(
+    url: string,
+    fileName?: string,
+    handlers?: ifm.IRequestHandler[],
+    additionalHeaders?: ifm.IHeaders
+): Promise<string> {
     return new Promise<string>(async (resolve, reject) => {
         try {
             handlers = handlers || null;
@@ -226,12 +231,6 @@ export async function downloadTool(url: string, fileName?: string, handlers?: if
 
             if (fs.existsSync(destPath)) {
                 throw new Error("Destination file path already exists");
-            }
-
-            const additionalHeaders: ifm.IHeaders = {};
-            if (auth) {
-                tl.debug('adding authorization header');
-                additionalHeaders['Authorization'] = auth;
             }
 
             tl.debug('downloading');

--- a/tool.ts
+++ b/tool.ts
@@ -197,7 +197,7 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
  * @param url                url of tool to download
  * @param fileName           optional fileName.  Should typically not use (will be a guid for reliability). Can pass fileName with an absolute path.
  * @param handlers           optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
- * @param additionalHeaders  optional custom HTTPheaders.  This is passed to the download client.
+ * @param additionalHeaders  optional custom HTTP headers.  This is passed to the download client.
  */
 export async function downloadTool(
     url: string,

--- a/tool.ts
+++ b/tool.ts
@@ -197,8 +197,9 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
  * @param url       url of tool to download
  * @param fileName  optional fileName.  Should typically not use (will be a guid for reliability). Can pass fileName with an absolute path.
  * @param handlers  optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
+ * @param auth      optional custom auth header value.  This is passed as a HTTP header to the download client.
  */
-export async function downloadTool(url: string, fileName?: string, handlers?: ifm.IRequestHandler[]): Promise<string> {
+export async function downloadTool(url: string, fileName?: string, handlers?: ifm.IRequestHandler[], auth?: string): Promise<string> {
     return new Promise<string>(async (resolve, reject) => {
         try {
             handlers = handlers || null;
@@ -226,7 +227,13 @@ export async function downloadTool(url: string, fileName?: string, handlers?: if
             if (fs.existsSync(destPath)) {
                 throw new Error("Destination file path already exists");
             }
-            
+
+            const additionalHeaders: ifm.IHeaders = {};
+            if (auth) {
+                tl.debug('adding authorization header');
+                additionalHeaders['Authorization'] = auth;
+            }
+
             tl.debug('downloading');
             let response: httpm.HttpClientResponse = await http.get(url);
             

--- a/tool.ts
+++ b/tool.ts
@@ -194,10 +194,10 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
 /**
  * Download a tool from an url and stream it into a file
  *
- * @param url       url of tool to download
- * @param fileName  optional fileName.  Should typically not use (will be a guid for reliability). Can pass fileName with an absolute path.
- * @param handlers  optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
- * @param auth      optional custom auth header value.  This is passed as a HTTP header to the download client.
+ * @param url                url of tool to download
+ * @param fileName           optional fileName.  Should typically not use (will be a guid for reliability). Can pass fileName with an absolute path.
+ * @param handlers           optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
+ * @param additionalHeaders  optional custom HTTPheaders.  This is passed to the download client.
  */
 export async function downloadTool(
     url: string,

--- a/tool.ts
+++ b/tool.ts
@@ -235,7 +235,7 @@ export async function downloadTool(url: string, fileName?: string, handlers?: if
             }
 
             tl.debug('downloading');
-            let response: httpm.HttpClientResponse = await http.get(url);
+            let response: httpm.HttpClientResponse = await http.get(url, additionalHeaders);
             
             if (response.message.statusCode != 200) {
                 let err: Error = new Error('Unexpected HTTP response: ' + response.message.statusCode);

--- a/tool.ts
+++ b/tool.ts
@@ -197,7 +197,7 @@ export function findLocalToolVersions(toolName: string, arch?: string) {
  * @param url                url of tool to download
  * @param fileName           optional fileName.  Should typically not use (will be a guid for reliability). Can pass fileName with an absolute path.
  * @param handlers           optional handlers array.  Auth handlers to pass to the HttpClient for the tool download.
- * @param additionalHeaders  optional custom HTTP headers.  This is passed to the download client.
+ * @param additionalHeaders  optional custom HTTP headers.  This is passed to the REST client that downloads the tool.
  */
 export async function downloadTool(
     url: string,


### PR DESCRIPTION
typed-rest-client doesn't support `Authorization: token ...` by default, so we need to pass it as an HTTP header.
This is needed for python release binary downloading from the [python versions registry](https://github.com/actions/python-versions).