### PR TITLE
Update pipeline images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,14 @@ jobs:
   steps:
   - template: azure-pipelines-steps.yml
 
+- job: 'Windows_2019'
+  pool:
+    vmImage: 'windows-2019'
+
+  steps:
+  - template: azure-pipelines-steps.yml
+
+
 - job: 'Windows_2022'
   pool:
     vmImage: 'windows-2022'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,9 +6,9 @@ jobs:
   steps:
   - template: azure-pipelines-steps.yml
 
-- job: 'VS2017_Win2016'
+- job: 'Windows_2022'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
 
   steps:
   - template: azure-pipelines-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,9 +34,9 @@ jobs:
     displayName: 'Publish npm artifact'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-- job: 'MacOS_1014'
+- job: 'MacOS_11'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-11'
 
   steps:
   - template: azure-pipelines-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,3 +40,10 @@ jobs:
 
   steps:
   - template: azure-pipelines-steps.yml
+
+- job: 'MacOS_12'
+  pool:
+    vmImage: 'macOS-12'
+
+  steps:
+  - template: azure-pipelines-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
-- job: 'Ubuntu_1804'
+- job: 'Ubuntu_2004'
   pool:
-    vmImage: 'Ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
 
   steps:
   - template: azure-pipelines-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,29 +2,36 @@ jobs:
 - job: 'Ubuntu_2004'
   pool:
     vmImage: 'ubuntu-20.04'
-
   steps:
   - template: azure-pipelines-steps.yml
 
 - job: 'Ubuntu_2204'
   pool:
     vmImage: 'ubuntu-22.04'
+  steps:
+  - template: azure-pipelines-steps.yml
 
+- job: 'MacOS_11'
+  pool:
+    vmImage: 'macOS-11'
+  steps:
+  - template: azure-pipelines-steps.yml
+
+- job: 'MacOS_12'
+  pool:
+    vmImage: 'macOS-12'
   steps:
   - template: azure-pipelines-steps.yml
 
 - job: 'Windows_2019'
   pool:
     vmImage: 'windows-2019'
-
   steps:
   - template: azure-pipelines-steps.yml
-
 
 - job: 'Windows_2022'
   pool:
     vmImage: 'windows-2022'
-
   steps:
   - template: azure-pipelines-steps.yml
 
@@ -48,17 +55,3 @@ jobs:
       artifactName: npm
     displayName: 'Publish npm artifact'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-
-- job: 'MacOS_11'
-  pool:
-    vmImage: 'macOS-11'
-
-  steps:
-  - template: azure-pipelines-steps.yml
-
-- job: 'MacOS_12'
-  pool:
-    vmImage: 'macOS-12'
-
-  steps:
-  - template: azure-pipelines-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,13 @@ jobs:
   steps:
   - template: azure-pipelines-steps.yml
 
+- job: 'Ubuntu_2204'
+  pool:
+    vmImage: 'ubuntu-22.04'
+
+  steps:
+  - template: azure-pipelines-steps.yml
+
 - job: 'Windows_2022'
   pool:
     vmImage: 'windows-2022'


### PR DESCRIPTION
vs2017-win2016 and macOS-10.14 images are not available in pipelines, ubuntu-18.04 deprecated.

This PR updates the images to run the pipelines.

Images to run:
- ubuntu-20.04
- ubuntu-22.04
- macOs-11
- macOs-12
- windows-2019
- windows-2022