### PR TITLE
Added logic to handle HTTP-errors during file downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,7 @@
 ### 2.0.0
 
 - Bump `azure-pipelines-task-lib` to `4.1.0`
+
+### 2.0.1
+
+- <https://github.com/microsoft/azure-pipelines-tool-lib/pull/184>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {


### PR DESCRIPTION
**Description of issue:**
Customers reported that sometimes `NodeTool` task silently passes without completing of downloading `node.js`. It happens due to the fact that there is no logic to handle `http` related errors

**Description of fix:**
I have added logic to handle `http` errors in function `downloadTool`

**How changes were tested:**
Looks like `nodejs.org` is throttling some customers and aborting their requests. I simulated such situation via tool `TCPView` on windows and `dsniff` on Ubuntu. I limited my network connection by npm-package `@sitespeed.io/throttle` to get more time to interact with TCP connections

**Screenshots:**
_Before_
![image](https://user-images.githubusercontent.com/11807074/220858703-6feae843-5894-47a0-9498-8ec9799b5117.png)
_After_
![image](https://user-images.githubusercontent.com/11807074/220858929-572b6d49-32d5-4e0b-b5f9-c41fefc92486.png)