### PR TITLE
Add subscription on "aborted" event for Node10 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@
 ### 2.0.1
 
 - <https://github.com/microsoft/azure-pipelines-tool-lib/pull/184>
+
+### 2.0.3
+
+- <https://github.com/microsoft/azure-pipelines-tool-lib/pull/189>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/tool.ts
+++ b/tool.ts
@@ -258,6 +258,11 @@ export async function downloadTool(
                                 file.end();
                                 reject(err);
                             })
+                            .on('aborted', () => {
+                                // this block is for Node10 compatibility since it doesn't emit 'error' event after 'aborted' one
+                                file.end();
+                                reject(new Error('Aborted'));
+                            })
                             .pipe(file);
                     } catch (err) {
                         reject(err);


### PR DESCRIPTION
**Description of issue:**
`Node10` doesn't emit event `error` when connection was aborted

**Description of fix:**
Added logic to subscribe on event `aborted` and reject promise to throw an exception. Exception is `Aborted` as it generated in `Node16` to make it consistent.

**How it was tested:**
Tested on self-hosted agent by replacing original code of `tool-lib` with my changes in `NodeTool` task.
_Before fix:_
![image](https://user-images.githubusercontent.com/11807074/224993529-117a20b8-45c4-4ac6-a177-c68d15334cdc.png)
_After fix:_
![image](https://user-images.githubusercontent.com/11807074/224993686-020d1769-f172-46f1-8bbc-84c9755492f7.png)

Successful run: https://abtttestorg.visualstudio.com/Other/_build/results?buildId=6265
Run with throttling issues: https://abtttestorg.visualstudio.com/Other/_build/results?buildId=6262