### PR TITLE
Fix bundlers not able to pick package.json at build time

### DIFF
--- a/tool.ts
+++ b/tool.ts
@@ -9,10 +9,10 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import * as trm from 'azure-pipelines-task-lib/toolrunner';
 const cmp = require('semver-compare');
 const uuidV4 = require('uuid/v4');
+const pkg = require('./package.json');
 
 declare let rest;
 
-let pkg = require(path.join(__dirname, 'package.json'));
 let userAgent = 'vsts-task-installer/' + pkg.version;
 let requestOptions = {
     // ignoreSslError: true,


### PR DESCRIPTION
This is a first (easy) step towards making the library compatible with bundlers (https://github.com/microsoft/azure-pipelines-tool-lib/issues/240)

As pointed out in [this issue](https://github.com/microsoft/azure-pipelines-tool-lib/issues/240), the runtime imports of `package.json` and `lib.json` break compatibility with bundlers such as esbuild. 