### PR TITLE
downloadTool fix: pre-check aborted & destroyed props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tool-lib",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
   "scripts": {

--- a/tool.ts
+++ b/tool.ts
@@ -205,7 +205,7 @@ export async function downloadTool(
     handlers?: ifm.IRequestHandler[],
     additionalHeaders?: ifm.IHeaders
 ): Promise<string> {
-    return new Promise<string>(async (resolve, reject) => {
+    return new Promise<string>(async (resolve, reject: (err: Error) => void) => {
         try {
             handlers = handlers || null;
             let http: httpm.HttpClient = new httpm.HttpClient(userAgent, handlers, requestOptions);
@@ -252,8 +252,16 @@ export async function downloadTool(
             const file: NodeJS.WritableStream = fs.createWriteStream(destPath);
             file
                 .on('open', async (fd) => {
+                    tl.debug('file write stream opened. fd: ' + fd);
+                    const messageSteam = response.message;
+                    if (messageSteam.aborted || messageSteam.destroyed) {
+                        file.end();
+                        reject(new Error('Incoming message read stream was Aborted or Destroyed before download was complete'));
+                        return;
+                    }
+                    tl.debug('subscribing to message read stream events...');
                     try {
-                        response.message
+                        messageSteam
                             .on('error', (err) => {
                                 file.end();
                                 reject(err);
@@ -303,16 +311,16 @@ export async function downloadTool(
 }
 
 export async function downloadToolWithRetries(
-        url: string,
-        fileName?: string,
-        handlers?: ifm.IRequestHandler[],
-        additionalHeaders?: ifm.IHeaders,
-        maxAttempts: number = 3,
-        retryInterval: number = 500
-    ): Promise<string>  {
+    url: string,
+    fileName?: string,
+    handlers?: ifm.IRequestHandler[],
+    additionalHeaders?: ifm.IHeaders,
+    maxAttempts: number = 3,
+    retryInterval: number = 500
+): Promise<string> {
     let attempt: number = 1;
     let destinationPath: string = ''
-    
+
     while (attempt <= maxAttempts && destinationPath == '') {
         try {
             destinationPath = await downloadTool(url, fileName, handlers, additionalHeaders);
@@ -322,7 +330,7 @@ export async function downloadToolWithRetries(
 
             // Error will be shown in downloadTool.
             tl.debug(`Attempt ${attempt} failed. Retrying after ${attemptInterval} ms`);
-            
+
             await delay(attemptInterval);
             attempt++;
         }
@@ -500,10 +508,10 @@ export async function extract7z(file: string, dest?: string, _7zPath?: string, o
             }
 
             _7z.arg('x')         // eXtract files with full paths
-               .arg('-bb1')      // -bb[0-3] : set output log level
-               .arg('-bd')       // disable progress indicator
-               .arg('-sccUTF-8') // set charset for for console input/output
-               .arg(file);
+                .arg('-bb1')      // -bb[0-3] : set output log level
+                .arg('-bd')       // disable progress indicator
+                .arg('-sccUTF-8') // set charset for for console input/output
+                .arg(file);
             await _7z.exec();
         }
         else {

--- a/tool.ts
+++ b/tool.ts
@@ -253,15 +253,15 @@ export async function downloadTool(
             file
                 .on('open', async (fd) => {
                     tl.debug('file write stream opened. fd: ' + fd);
-                    const messageSteam = response.message;
-                    if (messageSteam.aborted || messageSteam.destroyed) {
+                    const messageStream = response.message;
+                    if (messageStream.aborted || messageStream.destroyed) {
                         file.end();
                         reject(new Error('Incoming message read stream was Aborted or Destroyed before download was complete'));
                         return;
                     }
                     tl.debug('subscribing to message read stream events...');
                     try {
-                        messageSteam
+                        messageStream
                             .on('error', (err) => {
                                 file.end();
                                 reject(err);

--- a/tool.ts
+++ b/tool.ts
@@ -275,6 +275,7 @@ export async function downloadTool(
                     } catch (err) {
                         reject(err);
                     }
+                    tl.debug('successfully subscribed to message read stream events');
                 })
                 .on('close', () => {
                     tl.debug('download complete');


### PR DESCRIPTION
Sometimes we have a case then message stream was destroyed before we subscribed to it's events. 
This leads to case when we don't raise the promise.resolve and nodejs process exits with code 0.

fix should resolve the issue: https://github.com/microsoft/azure-pipelines-tasks/issues/20508