### PR TITLE
Release Pipeline Configuration for azure-pipeline-tool-lib to Public Registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 # This pipeline will be extended to the OneESPT template
 
 variables:
-- group: npm-tokens
+- group: tool-lib-npm-token
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,9 @@
 # This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
 # This pipeline will be extended to the OneESPT template
 
+variables:
+- group: npm-tokens
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -57,3 +60,4 @@ extends:
             artifactName: npm
         steps:
         - template: /azure-pipelines-steps.yml@self
+        - template: /release-pipeline.yml@self

--- a/make.js
+++ b/make.js
@@ -42,6 +42,7 @@ target.build = function () {
     run('tsc --outDir ' + buildPath, true);
     //cp(rp('typings.json'), buildPath);
     cp(rp('package.json'), buildPath);
+    cp(rp('publish.js'), buildPath);
     cp(rp('README.md'), buildPath);
     cp(rp('LICENSE'), buildPath);
     cp(rp('Invoke-7zdec.ps1'), buildPath);
@@ -145,7 +146,7 @@ var runTests = function (testPath) {
         tl.mkdirP(tempDir);
     }
 
-    run('mocha ' + testPath + ' --recursive --timeout 20000', true);
+    run('mocha ' + testPath + ' --recursive --timeout 20000 --retries 3', true);
 }
 
 target.units = function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "azure-pipelines-tool-lib",
+  "name": "@dassayantan/azure-pipelines-tool-lib-test",
   "version": "2.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "azure-pipelines-tool-lib",
+      "name": "@dassayantan/azure-pipelines-tool-lib-test",
       "version": "2.0.9",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dassayantan/azure-pipelines-tool-lib-test",
+  "name": "@dassayantan/azure-pipelines-tool-lib-v4",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
@@ -7,8 +7,7 @@
     "build": "node make.js build",
     "test": "node make.js test",
     "sample": "node make.js sample",
-    "units": "node make.js units",
-    "publish": "node publish.js"
+    "units": "node make.js units"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dassayantan/azure-pipelines-tool-lib-v4",
+  "name": "@dassayantan/azure-pipelines-tool-lib-v5",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",
@@ -7,7 +7,8 @@
     "build": "node make.js build",
     "test": "node make.js test",
     "sample": "node make.js sample",
-    "units": "node make.js units"
+    "units": "node make.js units",
+    "publish": "node publish.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dassayantan/azure-pipelines-tool-lib-v5",
+  "name": "@dassayantan/azure-pipelines-tool-lib-v6",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "node make.js build",
     "test": "node make.js test",
     "sample": "node make.js sample",
-    "units": "node make.js units"
+    "units": "node make.js units",
+    "publish": "node publish.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-pipelines-tool-lib",
+  "name": "@dassayantan/azure-pipelines-tool-lib",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dassayantan/azure-pipelines-tool-lib",
+  "name": "@dassayantan/azure-pipelines-tool-lib-test",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",

--- a/publish.js
+++ b/publish.js
@@ -8,15 +8,23 @@ const registryUrl = 'https://pkgs.dev.azure.com/dassayantan/dassayantan/_packagi
 console.log('Publishing npm package to private registry');
 
 try {
-    // Navigate to build directory (following your repo's pattern)
-    const buildPath = path.join(__dirname, '_build');
+    // Determine if we're already in the build directory or need to navigate to it
+    const currentDir = process.cwd();
+    const isInBuildDir = path.basename(currentDir) === '_build' && fs.existsSync('package.json');
     
-    if (!fs.existsSync(buildPath)) {
-        throw new Error(`Build directory not found: ${buildPath}. Please run 'npm run build' first.`);
+    if (!isInBuildDir) {
+        // We're in the project root, navigate to build directory
+        const buildPath = path.join(__dirname, '_build');
+        
+        if (!fs.existsSync(buildPath)) {
+            throw new Error(`Build directory not found: ${buildPath}. Please run 'npm run build' first.`);
+        }
+        
+        console.log(`Changing to build directory: ${buildPath}`);
+        process.chdir(buildPath);
+    } else {
+        console.log(`Already in build directory: ${currentDir}`);
     }
-    
-    console.log(`Changing to build directory: ${buildPath}`);
-    process.chdir(buildPath);
     
     // Verify package.json exists in build directory
     if (!fs.existsSync('package.json')) {

--- a/publish.js
+++ b/publish.js
@@ -45,7 +45,7 @@ always-auth=true
     
     // Publish to npm registry
     console.log(`Publishing to npm registry: ${registryUrl}`);
-    execSync(`npm publish --registry ${registryUrl}`, { stdio: 'inherit' });
+    execSync(`npm publish --registry ${registryUrl} --ignore-scripts`, { stdio: 'inherit' });
     console.log('Successfully published to npm!');
     
 } catch (error) {

--- a/publish.js
+++ b/publish.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Registry configuration
+const registryUrl = 'https://registry.npmjs.org/';
+
+console.log('Publishing npm package to public registry');
+
+try {
+    // Navigate to build directory (following your repo's pattern)
+    const buildPath = path.join(__dirname, '_build');
+    
+    if (!fs.existsSync(buildPath)) {
+        throw new Error(`Build directory not found: ${buildPath}. Please run 'npm run build' first.`);
+    }
+    
+    console.log(`Changing to build directory: ${buildPath}`);
+    process.chdir(buildPath);
+    
+    // Verify package.json exists in build directory
+    if (!fs.existsSync('package.json')) {
+        throw new Error('package.json not found in build directory');
+    }
+    
+    // Create .npmrc with auth token for public registry
+    const npmToken = process.env.NPM_TOKEN;
+    if (!npmToken) {
+        throw new Error('NPM_TOKEN environment variable is required');
+    }
+    
+    const npmrc = `//registry.npmjs.org/:_authToken=${npmToken}`;
+    console.log('Creating .npmrc for authentication...');
+    fs.writeFileSync('.npmrc', npmrc);
+    
+    // Publish to npm registry
+    console.log(`Publishing to npm registry: ${registryUrl}`);
+    execSync(`npm publish --registry ${registryUrl}`, { stdio: 'inherit' });
+    console.log('Successfully published to npm!');
+    
+} catch (error) {
+    console.error('Publish failed:', error.message);
+    if (error.message.includes('already exists')) {
+        console.log('Tip: Bump the version in package.json');
+    }
+    if (error.message.includes('401')) {
+        console.log('Tip: Check NPM_TOKEN permissions (read/write required)');
+    }
+    process.exit(1);
+}

--- a/publish.js
+++ b/publish.js
@@ -3,9 +3,9 @@ const { execSync } = require('child_process');
 const path = require('path');
 
 // Registry configuration
-const registryUrl = 'https://registry.npmjs.org/';
+const registryUrl = 'https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/';
 
-console.log('Publishing npm package to public registry');
+console.log('Publishing npm package to private registry');
 
 try {
     // Navigate to build directory (following your repo's pattern)
@@ -23,13 +23,15 @@ try {
         throw new Error('package.json not found in build directory');
     }
     
-    // Create .npmrc with auth token for public registry
+    // Create .npmrc with auth token for private registry
     const npmToken = process.env.NPM_TOKEN;
     if (!npmToken) {
         throw new Error('NPM_TOKEN environment variable is required');
     }
     
-    const npmrc = `//registry.npmjs.org/:_authToken=${npmToken}`;
+    const npmrc = `registry=${registryUrl}
+always-auth=true
+//pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=${npmToken}`;
     console.log('Creating .npmrc for authentication...');
     fs.writeFileSync('.npmrc', npmrc);
     
@@ -45,6 +47,9 @@ try {
     }
     if (error.message.includes('401')) {
         console.log('Tip: Check NPM_TOKEN permissions (read/write required)');
+    }
+    if (error.message.includes('upstream')) {
+        console.log('Tip: Use scoped package name like @dassayantan/azure-pipelines-tool-lib');
     }
     process.exit(1);
 }

--- a/release-pipeline.yml
+++ b/release-pipeline.yml
@@ -1,0 +1,8 @@
+steps:
+- bash: |
+    npm run publish
+  condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  env:
+    NPM_TOKEN: $(NPM_TOKEN)
+  displayName: 'Publish packages (Only Windows)'
+  enabled: true

--- a/release-pipeline.yml
+++ b/release-pipeline.yml
@@ -1,7 +1,7 @@
 steps:
 - bash: |
     npm run publish
-  condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['Agent.OS'], 'Windows_NT'))
   env:
     NPM_TOKEN: $(NPM_TOKEN)
   displayName: 'Publish packages (Only Windows)'

--- a/test/tests/toolTests.ts
+++ b/test/tests/toolTests.ts
@@ -171,7 +171,7 @@ describe('Tool Tests', function () {
     });
 
     it('download with basic authentication', function () {
-        this.timeout(2000);
+        this.timeout(20000);
 
         return new Promise<void>(async (resolve, reject) => {
             // General parameters:


### PR DESCRIPTION
This change implements automated npm publishing to npmjs.org for `azure-pipelines-tool-lib-test`. Includes publishing script, pipeline configuration, Windows-only publishing strategy, and enhanced test reliability with retries.

Key Changes:
- Added `publish.js` for npm publishing automation
- Configured `release-pipeline.yml` with conditional publishing
- Enhanced test timeouts and retry logic for CI stability

Work-Item: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2303569
Pipeline: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=30342076&view=results