### PR TITLE
Release Pipeline Integration for azure-pipeline-tool-lib to Public Registry | Part#2

### DIFF
--- a/.azure-pipelines/common-steps.yml
+++ b/.azure-pipelines/common-steps.yml
@@ -2,7 +2,6 @@
 # Shared build steps used across CI and release pipelines
 parameters:
 - name: includePackaging
-  default: 'false'
 
 steps:
   - checkout: self

--- a/.azure-pipelines/common-steps.yml
+++ b/.azure-pipelines/common-steps.yml
@@ -2,8 +2,6 @@
 # Shared build steps used across CI and release pipelines
 parameters:
 - name: includePackaging
-  type: boolean
-  default: false
 
 steps:
   - checkout: self
@@ -32,4 +30,4 @@ steps:
       npm pack
       cp *.tgz '$(Build.ArtifactStagingDirectory)'
     displayName: Run npm-pack and copy to ArtifactStagingDirectory
-    condition: eq('${{ parameters.includePackaging }}', true)
+    condition: eq('${{ parameters.includePackaging }}', 'true')

--- a/.azure-pipelines/common-steps.yml
+++ b/.azure-pipelines/common-steps.yml
@@ -2,6 +2,7 @@
 # Shared build steps used across CI and release pipelines
 parameters:
 - name: includePackaging
+  default: 'false'
 
 steps:
   - checkout: self

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -69,9 +69,20 @@ extends:
           - script: |
               echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
               echo 'always-auth=true' >> .npmrc
-              npm publish --ignore-scripts --tag prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
-              rm .npmrc
+            displayName: 'Create .npmrc with registry'
+
+          - task: NpmAuthenticate@0
+            displayName: 'Authenticate with Azure Artifacts'
+            inputs:
+              workingFile: .npmrc
+
+          - script: npm publish --ignore-scripts --tag prerelease
             displayName: 'Publish to Azure Artifacts as prerelease'
+            continueOnError: true
+
+          - script: rm .npmrc
+            displayName: 'Cleanup npm authentication'
+            condition: always()
             # condition: eq(variables['Build.SourceBranchName'], 'master')
             continueOnError: true
 
@@ -118,7 +129,12 @@ extends:
                   - script: |
                       echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
                       echo 'always-auth=true' >> .npmrc
-                    displayName: 'Setup Azure Artifacts authentication'
+                    displayName: 'Create .npmrc with registry'
+
+                  - task: NpmAuthenticate@0
+                    displayName: 'Authenticate with Azure Artifacts'
+                    inputs:
+                      workingFile: .npmrc
                   
                   - pwsh: |
                       # Get package name and version from package.json
@@ -133,7 +149,7 @@ extends:
                       Write-Host "##vso[task.setvariable variable=packageIdentifier]$packageName@$packageVersion"
                     displayName: 'Get package information'
                   
-                  - script: npm dist-tag add "$(packageIdentifier)" latest --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                  - script: npm dist-tag add "$(packageIdentifier)" latest
                     displayName: 'Promote package to latest'
                     continueOnError: true
                   
@@ -146,7 +162,7 @@ extends:
                       }
                     displayName: 'Check promotion status'
                   
-                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease
                     displayName: 'Remove prerelease tag'
                     continueOnError: true
                   

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -6,7 +6,7 @@
 trigger: none  # Manual trigger only
 
 variables:
-- group: npm-tokens
+- group: tool-lib-npm-tokens
 
 resources:
   repositories:
@@ -108,7 +108,7 @@ extends:
                   - task: NodeTool@0
                     displayName: Use Node 16
                     inputs:
-                      versionSpec: "16.x"
+                      versionSpec: "16.15.1"
                   
                   - task: NpmAuthenticate@0
                     displayName: 'Setup npm authentication'

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -54,7 +54,7 @@ extends:
         steps:
         - template: /.azure-pipelines/common-steps.yml@self
           parameters:
-            includePackaging: $(includePackaging)
+            includePackaging: 'true'
         
         # Conditional publishing - only from master branch
         - ${{ if eq(variables['build.reason'], 'Manual') }}:

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -1,24 +1,13 @@
 # Release pipeline for azure-pipelines-tool-lib
-# This pipeline publishes to npm with a two-stage process:
 # Stage 1: Publish as prerelease (automated)
 # Stage 2: Promote to latest (manual approval required)
 #
-# REGISTRY CONFIGURATION:
-# - Currently configured for Azure Artifacts private registry
-# - To switch to public npm: change registry URL to https://registry.npmjs.org/
-# - Requires 'tool-lib-npm-tokens' variable group with 'npm-automation.token'
-# - For Azure Artifacts: token should have packaging read/write permissions
-# - For public npm: token should be from npmjs.com with publish permissions
-#
-# AUTHENTICATION PATTERN:
-# - Creates .npmrc with registry, always-auth, and auth token (matches working Node.js script)
-# - Uses environment variables to securely pass the token
-# - All npm commands use --registry flag for explicit registry targeting
+# Currently configured for public npm registry
 
 trigger: none  # Manual trigger only
 
 variables:
-- group: tool-lib-npm-tokens
+- group: npm-tokens
 
 resources:
   repositories:
@@ -44,9 +33,7 @@ extends:
     - ES365AIMigrationTooling-Release
     
     stages:
-    # ================================
-    # STAGE 1: BUILD & PRERELEASE PUBLISHING (AUTOMATED)
-    # ================================
+    # Stage 1: Build and publish prerelease
     - stage: Build
       displayName: Build and Prerelease
       jobs:
@@ -68,24 +55,16 @@ extends:
           parameters:
             includePackaging: 'true'
         
-        # Conditional publishing - only from master branch
         - ${{ if eq(variables['build.reason'], 'Manual') }}:
-          # - script: |
-          #     echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
-          #     npm publish --ignore-scripts --tag prerelease
-          #     rm .npmrc
-          #   displayName: 'Publish to npm as prerelease'
-          #   # condition: eq(variables['Build.SourceBranchName'], 'master')
-          #   continueOnError: true
-          
           - bash: |
-              echo "Setting up npm authentication for private registry..."
+              echo "Setting up npm authentication for public registry..."
               export NPM_TOKEN=$(npm-automation.token)
-              echo registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ > .npmrc
+              echo registry=https://registry.npmjs.org/ > .npmrc
               echo always-auth=true >> .npmrc
-              echo //pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=$NPM_TOKEN >> .npmrc
+              echo //registry.npmjs.org/:_authToken=$NPM_TOKEN >> .npmrc
               
-              npm publish --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ --ignore-scripts --tag prerelease
+              # To test with private registry use: npm publish --registry https://xyz.private.registry.com/ --ignore-scripts --tag prerelease
+              npm publish --ignore-scripts --tag prerelease
               exit_status=$?
               if [ $exit_status -eq 1 ]; then
                   echo "##vso[task.logissue type=warning]Publishing azure-pipelines-tool-lib was unsuccessful"
@@ -93,13 +72,11 @@ extends:
               fi
               
               rm .npmrc
-            displayName: 'Publish to Azure Artifacts as prerelease'
+            displayName: 'Publish to npm as prerelease'
             env:
               NPM_TOKEN: $(npm-automation.token)
 
-    # ================================
-    # STAGE 2: RELEASE TO LATEST (MANUAL APPROVAL REQUIRED)
-    # ================================
+    # Stage 2: Promote to latest (manual approval required)
     - stage: Release
       displayName: Release to Latest
       dependsOn: Build
@@ -111,7 +88,7 @@ extends:
             name: 1ES-ABTT-Shared-Pool
             image: abtt-windows-2022
             os: windows
-          environment: 'npm-production'  # Requires manual approval
+          environment: 'npm-production'
           strategy:
             runOnce:
               deploy:
@@ -124,27 +101,22 @@ extends:
                     inputs:
                       versionSpec: "16.15.1"
                   
-                  # - script: echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
-                  #   displayName: 'Setup npm authentication'
-                  
                   - script: |
-                      echo "Setting up npm authentication for private registry..."
+                      echo "Setting up npm authentication for public registry..."
                       set NPM_TOKEN=$(npm-automation.token)
-                      echo registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ > .npmrc
+                      echo registry=https://registry.npmjs.org/ > .npmrc
                       echo always-auth=true >> .npmrc
-                      echo //pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=%NPM_TOKEN% >> .npmrc
+                      echo //registry.npmjs.org/:_authToken=%NPM_TOKEN% >> .npmrc
                     displayName: 'Create .npmrc with registry'
                     env:
                       NPM_TOKEN: $(npm-automation.token)
                   
                   - pwsh: |
-                      # Get package name and version from package.json
                       $packageInfo = Get-Content "package.json" | ConvertFrom-Json
                       $packageName = $packageInfo.name
                       $packageVersion = $packageInfo.version
                       Write-Host "Package: $packageName@$packageVersion"
                       
-                      # Store for next steps
                       Write-Host "##vso[task.setvariable variable=packageName]$packageName"
                       Write-Host "##vso[task.setvariable variable=packageVersion]$packageVersion"
                       Write-Host "##vso[task.setvariable variable=packageIdentifier]$packageName@$packageVersion"
@@ -153,7 +125,8 @@ extends:
                   - bash: |
                       export NPM_TOKEN=$(npm-automation.token)
                       
-                      npm dist-tag add "$(packageIdentifier)" latest --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                      # To test with private registry use: npm dist-tag add "$(packageIdentifier)" latest --registry https://xyz.private.registry.com/
+                      npm dist-tag add "$(packageIdentifier)" latest
                       exit_status=$?
                       if [ $exit_status -ne 0 ]; then
                           echo "##vso[task.logissue type=error]Failed to promote package to latest"
@@ -168,7 +141,8 @@ extends:
                   - bash: |
                       export NPM_TOKEN=$(npm-automation.token)
                       
-                      npm dist-tag rm "$(packageIdentifier)" prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                      # To test with private registry use: npm dist-tag rm "$(packageIdentifier)" prerelease --registry https://xyz.private.registry.com/
+                      npm dist-tag rm "$(packageIdentifier)" prerelease
                       exit_status=$?
                       if [ $exit_status -ne 0 ]; then
                           echo "##vso[task.logissue type=warning]Failed to remove prerelease tag, but package is now latest"

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -58,10 +58,18 @@ extends:
         
         # Conditional publishing - only from master branch
         - ${{ if eq(variables['build.reason'], 'Manual') }}:
+          # - script: |
+          #     echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
+          #     npm publish --ignore-scripts --tag prerelease
+          #     rm .npmrc
+          #   displayName: 'Publish to npm as prerelease'
+          #   # condition: eq(variables['Build.SourceBranchName'], 'master')
+          #   continueOnError: true
+          
           - script: |
               echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
               echo 'always-auth=true' >> .npmrc
-              npm publish --ignore-scripts --tag prerelease
+              npm publish --ignore-scripts --tag prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
               rm .npmrc
             displayName: 'Publish to Azure Artifacts as prerelease'
             # condition: eq(variables['Build.SourceBranchName'], 'master')
@@ -104,6 +112,9 @@ extends:
                     inputs:
                       versionSpec: "16.15.1"
                   
+                  # - script: echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
+                  #   displayName: 'Setup npm authentication'
+                  
                   - script: |
                       echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
                       echo 'always-auth=true' >> .npmrc
@@ -122,7 +133,7 @@ extends:
                       Write-Host "##vso[task.setvariable variable=packageIdentifier]$packageName@$packageVersion"
                     displayName: 'Get package information'
                   
-                  - script: npm dist-tag add "$(packageIdentifier)" latest
+                  - script: npm dist-tag add "$(packageIdentifier)" latest --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
                     displayName: 'Promote package to latest'
                     continueOnError: true
                   
@@ -135,7 +146,7 @@ extends:
                       }
                     displayName: 'Check promotion status'
                   
-                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease
+                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
                     displayName: 'Remove prerelease tag'
                     continueOnError: true
                   

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -78,38 +78,24 @@ extends:
           #   # condition: eq(variables['Build.SourceBranchName'], 'master')
           #   continueOnError: true
           
-          - script: |
+          - bash: |
               echo "Setting up npm authentication for private registry..."
-              set NPM_TOKEN=$(npm-automation.token)
+              export NPM_TOKEN=$(npm-automation.token)
               echo registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ > .npmrc
               echo always-auth=true >> .npmrc
-              echo //pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=%NPM_TOKEN% >> .npmrc
-              echo "Publishing to private registry..."
+              echo //pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=$NPM_TOKEN >> .npmrc
+              
               npm publish --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ --ignore-scripts --tag prerelease
-              del .npmrc
+              exit_status=$?
+              if [ $exit_status -eq 1 ]; then
+                  echo "##vso[task.logissue type=warning]Publishing azure-pipelines-tool-lib was unsuccessful"
+                  echo "##vso[task.complete result=SucceededWithIssues;]"
+              fi
+              
+              rm .npmrc
             displayName: 'Publish to Azure Artifacts as prerelease'
             env:
               NPM_TOKEN: $(npm-automation.token)
-            continueOnError: true
-
-          - script: |
-              echo "Current working directory:"
-              pwd
-              echo "npm config list:"
-              npm config list
-              echo "Contents of .npmrc (if exists):"
-              if exist .npmrc (type .npmrc) else (echo .npmrc does not exist)
-            displayName: 'Debug npm configuration'
-
-          - pwsh: |
-              if ($LASTEXITCODE -ne 0) {
-                  Write-Host "##vso[task.logissue type=warning]Publishing azure-pipelines-tool-lib was unsuccessful"
-                  Write-Host "##vso[task.complete result=SucceededWithIssues;]"
-              } else {
-                  Write-Host "Successfully published as prerelease"
-              }
-            displayName: 'Check publish status'
-            # condition: eq(variables['Build.SourceBranchName'], 'master')
 
     # ================================
     # STAGE 2: RELEASE TO LATEST (MANUAL APPROVAL REQUIRED)
@@ -164,41 +150,34 @@ extends:
                       Write-Host "##vso[task.setvariable variable=packageIdentifier]$packageName@$packageVersion"
                     displayName: 'Get package information'
                   
-                  - script: |
-                      echo "Debug: Contents of .npmrc:"
-                      if exist .npmrc (type .npmrc) else (echo .npmrc does not exist)
-                      echo "npm config list:"
-                      npm config list
-                    displayName: 'Debug npm configuration for release'
-                  
-                  - script: npm dist-tag add "$(packageIdentifier)" latest --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                  - bash: |
+                      export NPM_TOKEN=$(npm-automation.token)
+                      
+                      npm dist-tag add "$(packageIdentifier)" latest --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                      exit_status=$?
+                      if [ $exit_status -ne 0 ]; then
+                          echo "##vso[task.logissue type=error]Failed to promote package to latest"
+                          exit 1
+                      else
+                          echo "Successfully promoted $(packageIdentifier) to latest"
+                      fi
                     displayName: 'Promote package to latest'
                     env:
                       NPM_TOKEN: $(npm-automation.token)
-                    continueOnError: true
                   
-                  - pwsh: |
-                      if ($LASTEXITCODE -ne 0) {
-                          Write-Host "##vso[task.logissue type=error]Failed to promote package to latest"
-                          exit 1
-                      } else {
-                          Write-Host "Successfully promoted $(packageIdentifier) to latest"
-                      }
-                    displayName: 'Check promotion status'
-                  
-                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                  - bash: |
+                      export NPM_TOKEN=$(npm-automation.token)
+                      
+                      npm dist-tag rm "$(packageIdentifier)" prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
+                      exit_status=$?
+                      if [ $exit_status -ne 0 ]; then
+                          echo "##vso[task.logissue type=warning]Failed to remove prerelease tag, but package is now latest"
+                      else
+                          echo "Successfully removed prerelease tag from $(packageIdentifier)"
+                      fi
                     displayName: 'Remove prerelease tag'
                     env:
                       NPM_TOKEN: $(npm-automation.token)
-                    continueOnError: true
-                  
-                  - pwsh: |
-                      if ($LASTEXITCODE -ne 0) {
-                          Write-Host "##vso[task.logissue type=warning]Failed to remove prerelease tag, but package is now latest"
-                      } else {
-                          Write-Host "Successfully removed prerelease tag from $(packageIdentifier)"
-                      }
-                    displayName: 'Check prerelease removal status'
                   
                   - script: del .npmrc
                     displayName: 'Cleanup npm authentication'

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -69,12 +69,8 @@ extends:
           - script: |
               echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
               echo 'always-auth=true' >> .npmrc
+              echo '//pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=$(npm-automation.token)' >> .npmrc
             displayName: 'Create .npmrc with registry'
-
-          - task: NpmAuthenticate@0
-            displayName: 'Authenticate with Azure Artifacts'
-            inputs:
-              workingFile: .npmrc
 
           - script: npm publish --ignore-scripts --tag prerelease
             displayName: 'Publish to Azure Artifacts as prerelease'
@@ -129,12 +125,8 @@ extends:
                   - script: |
                       echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
                       echo 'always-auth=true' >> .npmrc
+                      echo '//pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=$(npm-automation.token)' >> .npmrc
                     displayName: 'Create .npmrc with registry'
-
-                  - task: NpmAuthenticate@0
-                    displayName: 'Authenticate with Azure Artifacts'
-                    inputs:
-                      workingFile: .npmrc
                   
                   - pwsh: |
                       # Get package name and version from package.json

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -2,6 +2,18 @@
 # This pipeline publishes to npm with a two-stage process:
 # Stage 1: Publish as prerelease (automated)
 # Stage 2: Promote to latest (manual approval required)
+#
+# REGISTRY CONFIGURATION:
+# - Currently configured for Azure Artifacts private registry
+# - To switch to public npm: change registry URL to https://registry.npmjs.org/
+# - Requires 'tool-lib-npm-tokens' variable group with 'npm-automation.token'
+# - For Azure Artifacts: token should have packaging read/write permissions
+# - For public npm: token should be from npmjs.com with publish permissions
+#
+# AUTHENTICATION PATTERN:
+# - Creates .npmrc with registry, always-auth, and auth token (matches working Node.js script)
+# - Uses environment variables to securely pass the token
+# - All npm commands use --registry flag for explicit registry targeting
 
 trigger: none  # Manual trigger only
 
@@ -67,32 +79,27 @@ extends:
           #   continueOnError: true
           
           - script: |
-              echo "Creating .npmrc file..."
-              echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
-              echo 'always-auth=true' >> .npmrc
-              echo '//pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=$(npm-automation.token)' >> .npmrc
-              echo "Contents of .npmrc:"
-              type .npmrc
-            displayName: 'Create .npmrc with registry'
+              echo "Setting up npm authentication for private registry..."
+              set NPM_TOKEN=$(npm-automation.token)
+              echo registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ > .npmrc
+              echo always-auth=true >> .npmrc
+              echo //pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=%NPM_TOKEN% >> .npmrc
+              echo "Publishing to private registry..."
+              npm publish --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ --ignore-scripts --tag prerelease
+              del .npmrc
+            displayName: 'Publish to Azure Artifacts as prerelease'
+            env:
+              NPM_TOKEN: $(npm-automation.token)
+            continueOnError: true
 
           - script: |
               echo "Current working directory:"
               pwd
               echo "npm config list:"
               npm config list
-              echo "Current .npmrc contents:"
-              type .npmrc
+              echo "Contents of .npmrc (if exists):"
+              if exist .npmrc (type .npmrc) else (echo .npmrc does not exist)
             displayName: 'Debug npm configuration'
-
-          - script: npm publish --ignore-scripts --tag prerelease --userconfig .npmrc
-            displayName: 'Publish to Azure Artifacts as prerelease'
-            continueOnError: true
-
-          - script: rm .npmrc
-            displayName: 'Cleanup npm authentication'
-            condition: always()
-            # condition: eq(variables['Build.SourceBranchName'], 'master')
-            continueOnError: true
 
           - pwsh: |
               if ($LASTEXITCODE -ne 0) {
@@ -135,10 +142,14 @@ extends:
                   #   displayName: 'Setup npm authentication'
                   
                   - script: |
-                      echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
-                      echo 'always-auth=true' >> .npmrc
-                      echo '//pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=$(npm-automation.token)' >> .npmrc
+                      echo "Setting up npm authentication for private registry..."
+                      set NPM_TOKEN=$(npm-automation.token)
+                      echo registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/ > .npmrc
+                      echo always-auth=true >> .npmrc
+                      echo //pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=%NPM_TOKEN% >> .npmrc
                     displayName: 'Create .npmrc with registry'
+                    env:
+                      NPM_TOKEN: $(npm-automation.token)
                   
                   - pwsh: |
                       # Get package name and version from package.json
@@ -153,8 +164,17 @@ extends:
                       Write-Host "##vso[task.setvariable variable=packageIdentifier]$packageName@$packageVersion"
                     displayName: 'Get package information'
                   
-                  - script: npm dist-tag add "$(packageIdentifier)" latest --userconfig .npmrc
+                  - script: |
+                      echo "Debug: Contents of .npmrc:"
+                      if exist .npmrc (type .npmrc) else (echo .npmrc does not exist)
+                      echo "npm config list:"
+                      npm config list
+                    displayName: 'Debug npm configuration for release'
+                  
+                  - script: npm dist-tag add "$(packageIdentifier)" latest --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
                     displayName: 'Promote package to latest'
+                    env:
+                      NPM_TOKEN: $(npm-automation.token)
                     continueOnError: true
                   
                   - pwsh: |
@@ -166,8 +186,10 @@ extends:
                       }
                     displayName: 'Check promotion status'
                   
-                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease --userconfig .npmrc
+                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease --registry https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/
                     displayName: 'Remove prerelease tag'
+                    env:
+                      NPM_TOKEN: $(npm-automation.token)
                     continueOnError: true
                   
                   - pwsh: |
@@ -178,6 +200,6 @@ extends:
                       }
                     displayName: 'Check prerelease removal status'
                   
-                  - script: rm .npmrc
+                  - script: del .npmrc
                     displayName: 'Cleanup npm authentication'
                     condition: always()

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -59,10 +59,11 @@ extends:
         # Conditional publishing - only from master branch
         - ${{ if eq(variables['build.reason'], 'Manual') }}:
           - script: |
-              echo '//dev.azure.com/dassayantan/dassayantan/_artifacts/feed/TestPackages:_authToken=$(npm-automation.token)' > .npmrc
+              echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
+              echo 'always-auth=true' >> .npmrc
               npm publish --ignore-scripts --tag prerelease
               rm .npmrc
-            displayName: 'Publish to npm as prerelease'
+            displayName: 'Publish to Azure Artifacts as prerelease'
             # condition: eq(variables['Build.SourceBranchName'], 'master')
             continueOnError: true
 
@@ -103,8 +104,10 @@ extends:
                     inputs:
                       versionSpec: "16.15.1"
                   
-                  - script: echo '//dev.azure.com/dassayantan/dassayantan/_artifacts/feed/TestPackages:_authToken=$(npm-automation.token)' > .npmrc
-                    displayName: 'Setup npm authentication'
+                  - script: |
+                      echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
+                      echo 'always-auth=true' >> .npmrc
+                    displayName: 'Setup Azure Artifacts authentication'
                   
                   - pwsh: |
                       # Get package name and version from package.json

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -67,10 +67,22 @@ extends:
           #   continueOnError: true
           
           - script: |
+              echo "Creating .npmrc file..."
               echo 'registry=https://pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/' > .npmrc
               echo 'always-auth=true' >> .npmrc
               echo '//pkgs.dev.azure.com/dassayantan/dassayantan/_packaging/TestPackages/npm/registry/:_authToken=$(npm-automation.token)' >> .npmrc
+              echo "Contents of .npmrc:"
+              type .npmrc
             displayName: 'Create .npmrc with registry'
+
+          - script: |
+              echo "Current working directory:"
+              pwd
+              echo "npm config list:"
+              npm config list
+              echo "Current .npmrc contents:"
+              type .npmrc
+            displayName: 'Debug npm configuration'
 
           - script: npm publish --ignore-scripts --tag prerelease
             displayName: 'Publish to Azure Artifacts as prerelease'

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -6,7 +6,7 @@
 trigger: none  # Manual trigger only
 
 variables:
-- group: tool-lib-npm-tokens
+- group: npm-tokens
 
 resources:
   repositories:
@@ -58,13 +58,10 @@ extends:
         
         # Conditional publishing - only from master branch
         - ${{ if in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
-          - task: NpmAuthenticate@0
-            displayName: 'Setup npm authentication'
-            inputs:
-              workingFile: .npmrc
-            condition: eq(variables['Build.SourceBranchName'], 'master')
-
-          - script: npm publish --ignore-scripts --tag prerelease
+          - script: |
+              echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
+              npm publish --ignore-scripts --tag prerelease
+              rm .npmrc
             displayName: 'Publish to npm as prerelease'
             condition: eq(variables['Build.SourceBranchName'], 'master')
             continueOnError: true
@@ -78,10 +75,6 @@ extends:
               }
             displayName: 'Check publish status'
             condition: eq(variables['Build.SourceBranchName'], 'master')
-
-          - pwsh: Remove-Item -Path ".npmrc" -Force -ErrorAction SilentlyContinue
-            displayName: 'Cleanup npm authentication'
-            condition: always()
 
     # ================================
     # STAGE 2: RELEASE TO LATEST (MANUAL APPROVAL REQUIRED)
@@ -110,10 +103,8 @@ extends:
                     inputs:
                       versionSpec: "16.15.1"
                   
-                  - task: NpmAuthenticate@0
+                  - script: echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
                     displayName: 'Setup npm authentication'
-                    inputs:
-                      workingFile: .npmrc
                   
                   - pwsh: |
                       # Get package name and version from package.json
@@ -153,6 +144,6 @@ extends:
                       }
                     displayName: 'Check prerelease removal status'
                   
-                  - pwsh: Remove-Item -Path ".npmrc" -Force -ErrorAction SilentlyContinue
+                  - script: rm .npmrc
                     displayName: 'Cleanup npm authentication'
                     condition: always()

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -6,7 +6,7 @@
 trigger: none  # Manual trigger only
 
 variables:
-- group: npm-tokens
+- group: tool-lib-npm-tokens
 
 resources:
   repositories:
@@ -57,13 +57,13 @@ extends:
             includePackaging: $(includePackaging)
         
         # Conditional publishing - only from master branch
-        - ${{ if in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual') }}:
+        - ${{ if eq(variables['build.reason'], 'Manual') }}:
           - script: |
-              echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
+              echo '//dev.azure.com/dassayantan/dassayantan/_artifacts/feed/TestPackages:_authToken=$(npm-automation.token)' > .npmrc
               npm publish --ignore-scripts --tag prerelease
               rm .npmrc
             displayName: 'Publish to npm as prerelease'
-            condition: eq(variables['Build.SourceBranchName'], 'master')
+            # condition: eq(variables['Build.SourceBranchName'], 'master')
             continueOnError: true
 
           - pwsh: |
@@ -74,7 +74,7 @@ extends:
                   Write-Host "Successfully published as prerelease"
               }
             displayName: 'Check publish status'
-            condition: eq(variables['Build.SourceBranchName'], 'master')
+            # condition: eq(variables['Build.SourceBranchName'], 'master')
 
     # ================================
     # STAGE 2: RELEASE TO LATEST (MANUAL APPROVAL REQUIRED)
@@ -103,7 +103,7 @@ extends:
                     inputs:
                       versionSpec: "16.15.1"
                   
-                  - script: echo '//registry.npmjs.org/:_authToken=$(npm-automation.token)' > .npmrc
+                  - script: echo '//dev.azure.com/dassayantan/dassayantan/_artifacts/feed/TestPackages:_authToken=$(npm-automation.token)' > .npmrc
                     displayName: 'Setup npm authentication'
                   
                   - pwsh: |

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -84,7 +84,7 @@ extends:
               type .npmrc
             displayName: 'Debug npm configuration'
 
-          - script: npm publish --ignore-scripts --tag prerelease
+          - script: npm publish --ignore-scripts --tag prerelease --userconfig .npmrc
             displayName: 'Publish to Azure Artifacts as prerelease'
             continueOnError: true
 
@@ -153,7 +153,7 @@ extends:
                       Write-Host "##vso[task.setvariable variable=packageIdentifier]$packageName@$packageVersion"
                     displayName: 'Get package information'
                   
-                  - script: npm dist-tag add "$(packageIdentifier)" latest
+                  - script: npm dist-tag add "$(packageIdentifier)" latest --userconfig .npmrc
                     displayName: 'Promote package to latest'
                     continueOnError: true
                   
@@ -166,7 +166,7 @@ extends:
                       }
                     displayName: 'Check promotion status'
                   
-                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease
+                  - script: npm dist-tag rm "$(packageIdentifier)" prerelease --userconfig .npmrc
                     displayName: 'Remove prerelease tag'
                     continueOnError: true
                   

--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -55,7 +55,7 @@ extends:
           parameters:
             includePackaging: 'true'
         
-        - ${{ if eq(variables['build.reason'], 'Manual') }}:
+        - ${{ if and(eq(variables['build.reason'], 'Manual'), eq(variables['Build.SourceBranchName'], 'master')) }}:
           - bash: |
               echo "Setting up npm authentication for public registry..."
               export NPM_TOKEN=$(npm-automation.token)
@@ -67,8 +67,8 @@ extends:
               npm publish --ignore-scripts --tag prerelease
               exit_status=$?
               if [ $exit_status -eq 1 ]; then
-                  echo "##vso[task.logissue type=warning]Publishing azure-pipelines-tool-lib was unsuccessful"
-                  echo "##vso[task.complete result=SucceededWithIssues;]"
+                  echo "##vso[task.logissue type=error]Publishing azure-pipelines-tool-lib was unsuccessful"
+                  exit 1
               fi
               
               rm .npmrc
@@ -80,7 +80,7 @@ extends:
     - stage: Release
       displayName: Release to Latest
       dependsOn: Build
-      condition: succeeded()
+      condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
       jobs:
         - deployment: ReleaseToLatest
           displayName: Promote to Latest Tag

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,8 @@ extends:
           os: linux
         steps:
         - template: /.azure-pipelines/common-steps.yml@self
+          parameters:
+            includePackaging: 'false'
       - job: 'MacOS_12'
         pool:
           name: Azure Pipelines
@@ -39,6 +41,8 @@ extends:
           os: macOS
         steps:
         - template: /.azure-pipelines/common-steps.yml@self
+          parameters:
+            includePackaging: 'false'
       - job: 'Windows_2022'
         pool:
           name: 1ES-ABTT-Shared-Pool
@@ -57,3 +61,5 @@ extends:
             artifactName: npm
         steps:
         - template: /.azure-pipelines/common-steps.yml@self
+          parameters:
+            includePackaging: 'false'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dassayantan/azure-pipelines-tool-lib-v8",
+  "name": "azure-pipelines-tool-lib-v9",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-pipelines-tool-lib-v10",
+  "name": "azure-pipelines-tool-lib",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dassayantan/azure-pipelines-tool-lib-v7",
+  "name": "@dassayantan/azure-pipelines-tool-lib-v8",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-pipelines-tool-lib-v9",
+  "name": "azure-pipelines-tool-lib-v10",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-pipelines-tool-lib",
+  "name": "@dassayantan/azure-pipelines-tool-lib-v7",
   "version": "2.0.9",
   "description": "Azure Pipelines Tool Installer Lib for CI/CD Tasks",
   "main": "tool.js",


### PR DESCRIPTION
This change implements automated publishing to https://www.npmjs.org for the azure-pipelines-tool-lib-test package.
It follows a Windows-only publishing strategy and integrates the release pipeline for azure-pipeline-tool-lib with the public npm registry.

Work-Item: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2303569
Pipeline: https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=30365114&view=results
