### PR TITLE
Update github actions to pin to a commit

### DIFF
--- a/.github/workflows/localization-automerge.yml
+++ b/.github/workflows/localization-automerge.yml
@@ -13,7 +13,7 @@ jobs:
 
     if: github.actor == 'csigs'
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
[Pinning | SDL Home](https://eng.ms/docs/microsoft-security/ciso-organization/sr-assurance/cspa/sdl-home/sdl-home/osssecurity/githubactions/pinning)
[Requirement to pin Github Actions to a commit sha instead of standard version tags | Docs](https://docs.opensource.microsoft.com/announcements/2026-08-07-github-actions-commit-pinning/)

Pinning to version [3.2.0 actions/github-scripts](https://github.com/actions/github-script/commit/ffc2c79a5b2490bd33e0a41c1de74b877714d736).
This version is currently deprecated but will be updated to a new version in an upcoming PR.
These pipelines are not really used anymore